### PR TITLE
Require POSIX spawn libs immediately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 1.8.7

--- a/lib/sensu/spawn.rb
+++ b/lib/sensu/spawn.rb
@@ -5,6 +5,13 @@ gem "childprocess", "0.5.3"
 require "eventmachine"
 require "em/worker"
 require "childprocess"
+require "ffi"
+
+begin
+  require "childprocess/unix/platform/#{ChildProcess.platform_name}"
+  require "childprocess/unix/lib"
+  require "childprocess/unix/posix_spawn_process"
+rescue LoadError; end
 
 module Sensu
   module Spawn

--- a/sensu-spawn.gemspec
+++ b/sensu-spawn.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "codeclimate-test-reporter" unless RUBY_VERSION < "1.9"
 end


### PR DESCRIPTION
A Sensu Enterprise user discovered a load issue, within the EventMachine thread pool. Loading the POSIX spawn libs when `sensu-spawn` is required eliminates the chance for a race condition.