### PR TITLE
Add concurrency variable from client settings

### DIFF
--- a/lib/sensu/spawn.rb
+++ b/lib/sensu/spawn.rb
@@ -34,6 +34,7 @@ module Sensu
         create = Proc.new do
           child_process(command, options)
         end
+        concurrency = options.fetch(:concurrency, 12)
         @process_worker ||= EM::Worker.new(:concurrency => 12)
         @process_worker.enqueue(create, callback)
       end


### PR DESCRIPTION
Allows sensu clients to set maximum number of concurrent event machine workers.

Needs this pull requests from sensu/sensu to be applied as well: https://github.com/sensu/sensu/pull/1186

Resolves this issue: https://github.com/sensu/sensu/issues/1184