### PR TITLE
Configurable spawn child process limit

### DIFF
--- a/spec/spawn_spec.rb
+++ b/spec/spawn_spec.rb
@@ -4,6 +4,10 @@ require "sensu/spawn"
 describe "Sensu::Spawn" do
   include Helpers
 
+  it "can setup a process worker" do
+    Sensu::Spawn.setup(:limit => 20)
+  end
+
   it "can spawn a process" do
     async_wrapper do
       Sensu::Spawn.process("echo foo") do |output, status|


### PR DESCRIPTION
This pull requests allows the max number of child processes to be configured by Sensu."

![ukl8tjg](https://cloud.githubusercontent.com/assets/149630/15308397/a1fed50e-1b91-11e6-9e3d-e11621b2a1b3.gif)
