### PR TITLE
Revert "Only enable posix spawn on x86_64 and i386"

### DIFF
--- a/lib/sensu/spawn.rb
+++ b/lib/sensu/spawn.rb
@@ -20,7 +20,6 @@ rescue LoadError; end
 module Sensu
   module Spawn
     POSIX_SPAWN_PLATFORMS = [:linux, :macosx].freeze
-    POSIX_SPAWN_ARCHS = ["x86_64", "i386"].freeze
 
     @@mutex = Mutex.new
 
@@ -63,9 +62,7 @@ module Sensu
       # @return [TrueClass, FalseClass]
       def posix_spawn?
         return @posix_spawn unless @posix_spawn.nil?
-        platform_supported = POSIX_SPAWN_PLATFORMS.include?(ChildProcess.os)
-        arch_supported = POSIX_SPAWN_ARCHS.include?(ChildProcess.arch)
-        @posix_spawn = platform_supported && arch_supported
+        @posix_spawn = POSIX_SPAWN_PLATFORMS.include?(ChildProcess.os)
       end
 
       # Determine if the current platform is Windows.


### PR DESCRIPTION
Reverts sensu/sensu-spawn#23

CentOS 6 segfaulting:
```
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/childprocess-0.5.8/lib/childprocess/unix/lib.rb:102: [BUG] Segmentation fault at 0x00000000000120
```