### PR TITLE
Include stop error message in timeout output

### DIFF
--- a/lib/sensu/spawn.rb
+++ b/lib/sensu/spawn.rb
@@ -159,8 +159,13 @@ module Sensu
         end
         [output, child.exit_code]
       rescue ChildProcess::TimeoutError
-        child.stop rescue nil
-        ["Execution timed out", 2]
+        output = "Execution timed out"
+        begin
+          child.stop
+        rescue => error
+          output += " - Unable to TERM/KILL the process: #{error}"
+        end
+        [output, 2]
       rescue => error
         child.stop rescue nil
         ["Unexpected error: #{error}", 3]

--- a/lib/sensu/spawn.rb
+++ b/lib/sensu/spawn.rb
@@ -163,7 +163,8 @@ module Sensu
         begin
           child.stop
         rescue => error
-          output += " - Unable to TERM/KILL the process: #{error}"
+          pid = child.pid rescue "?"
+          output += " - Unable to TERM/KILL the process: ##{pid}, #{error}"
         end
         [output, 2]
       rescue => error


### PR DESCRIPTION
This pull-request adds process stop error messages to the timeout
output, for example:

`"output":"Execution timed out - Unable to TERM/KILL the process: Operation not permitted"`